### PR TITLE
Update Readme.md to match GH Actions builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ and modules.
 | 1.19.10       | linux | musl           | open telemetry (latest commit) |
 | 1.20.1        | linux | libc           | open telemetry (latest commit) |
 | 1.20.1        | linux | musl           | open telemetry (latest commit) |
-| 1.21.4        | linux | libc           | open telemetry (latest commit) |
-| 1.21.4        | linux | musl           | open telemetry (latest commit) |
+| 1.21.5        | linux | libc           | open telemetry (latest commit) |
+| 1.21.5        | linux | musl           | open telemetry (latest commit) |
+| 1.21.6        | linux | libc           | open telemetry (latest commit) |
+| 1.21.6        | linux | musl           | open telemetry (latest commit) |
 
 # Usage
 


### PR DESCRIPTION
This PR updates the Readme to match Github Actions not [building](https://github.com/nginxinc/nginx-unsupported-modules/blob/aa37e892f3e10ab34d6f07278b3d4dcd76ed1782/.github/workflows/ci.yml#L56) v.1.21.4 any longer.